### PR TITLE
Use template for config management

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This roles sets up a ssh server with its configuration on a Debian (based) syste
 Requirements
 ----------------
 
-* Ansible role [xamanu.user](https://galaxy.ansible.com/xamanu/user/)
+One or multiple users must be member of the `ssh_login` group. Group
+Membership is not managed by this role.
+
+SSH keys of the authorized users must be present in the
+`~/.ssh/authorized_keys` file. Keys are not managed by this role.
+
+Ansible role [xamanu.user](https://galaxy.ansible.com/xamanu/user/) may be
+used to manage a default user with group membership and keys.
 
 Configuration
 ----------------
@@ -14,8 +21,8 @@ Configuration
 -* Only connections with ssh key authentication are possible (no password login).
 -* `root` access is generally not allowed.
 -* Only users that are members of the `ssh_login` group can login through ssh.
+-* The group can be configured via the `secure_ssh_group` variable.
 -* Port is switched from `22` to the indicated value from the ansible variable `secure_ssh_port`, which can be [specified conveniently](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#host-variables) in the `ansible.hosts` file.
--* A link to download the `authorized_keys` file for ssh must be specified with the variable `ssh_authorized_keys`.
 
 
 This is work in progress and it is prefered to collaborate on it. Please communicate over the issue queue. Every pull request is highly appreciated.
@@ -23,13 +30,13 @@ This is work in progress and it is prefered to collaborate on it. Please communi
 Example Playbook
 ----------------
 
-    - hosts: servers
-      roles:
-         - { role: xamanu.essentials }
+```yaml
+- hosts: servers
+  roles:
+     - { role: xamanu.essentials }
+```
 
-
-
-**You can connect directly with**: 
+**You can connect directly with**:
 
 -`ssh -p YOURPORT user@123.456.789.1`
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 secure_ssh_port: 22
+secure_ssh_group: ssh_login

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,43 +4,27 @@
     with_items:
       - openssh-server
 
-  - group:
-      name: ssh_login
+  - name: Check if ssh_login group exists
+    group:
+      name: "{{ secure_ssh_group }}"
       state: present
+    register: logingroup
+    check_mode: yes # do not create group
 
-  - name: Adding existing user to group ssh_login
-    user: name=user
-          groups=ssh_login
-          append=yes
+# At this point, at least one user must be present which is member
+# of ssh_login, otherwise we will lock ourselves out of the system!
+# If the group was just created, that means this is probably not the case.
+  - fail:
+      msg: "{{ secure_ssh_group }} must exist, you will lock yourself out of the system!"
+    when: logingroup.changed
 
-
-  - name: Make sure that the .ssh directory exsists
-    file:
-      path: "/home/user/.ssh"
-      state: directory
-      mode: 0755
-
-  - name: Download authorized_keys file
-    get_url:
-      url: "{{ ssh_authorized_keys }}"
-      dest: "/home/user/.ssh/authorized_keys"
-      owner: user
-      group: user
-      mode: 0644
-
-  - name: Secured ssh configuration (disallows password login)
-    copy:
-      src: "files/sshd_config"
-      dest: /etc/ssh/sshd_config
+  - name: Secured ssh configuration (disallows password login!)
+    template:
+      src: "sshd_config.j2"
+      dest: "/etc/ssh/sshd_config"
       owner: root
       group: root
       mode: 0644
       backup: yes
-
-  - name: Setup alternate SSH port (if specified)
-    lineinfile:
-      dest: "/etc/ssh/sshd_config"
-      regexp: "^Port"
-      line: "Port {{ secure_ssh_port }}"
     notify:
       - restart ssh

--- a/templates/sshd_config.j2
+++ b/templates/sshd_config.j2
@@ -10,7 +10,7 @@
 # possible, but leave them commented.  Uncommented options override the
 # default value.
 
-Port 2222
+Port {{ secure_ssh_port }}
 #AddressFamily any
 #ListenAddress 0.0.0.0
 #ListenAddress ::
@@ -30,7 +30,7 @@ Port 2222
 
 LoginGraceTime 2m
 PermitRootLogin no
-AllowGroups ssh_login
+AllowGroups {{ secure_ssh_group }}
 #StrictModes yes
 #MaxAuthTries 6
 #MaxSessions 10


### PR DESCRIPTION
This MR uses a template file for easy configuration management. Changing of the port via a regex call was removed.

The allowed groups for ssh were added as a default variable.

A check makes sure that the group actually exists before changing the configuration file, in order to not lock the user out of the system.

The user will no longer be added to the ssh-login group automatically, this will be added as functionality for the `ansible-role-user` role.

The keys of the user will no longer be downloaded via HTTP(S), this will be added as functionality for the `ansible-role-user` role.